### PR TITLE
Add create timetables

### DIFF
--- a/src/Timetable.py
+++ b/src/Timetable.py
@@ -1,0 +1,37 @@
+from enum import Enum
+
+
+class Type(str, Enum):
+    CDC = "CDC"
+    DEL = "DEL"
+    HUEL = "HUEL"
+    OPEL = "OPEL"
+
+
+class TimetableCell:
+    def __init__(self, code: str, section: str, type: Type):
+        self.code = code
+        self.section = section
+        self.type = type
+
+
+class Timetable:
+    def __init__(self, num, n_days, n_hours):
+        self.num = num
+        self.timetable = [[None for _ in range(n_days)] for _ in range(n_hours)]
+        self.daily_tally = {
+            "Monday": 0,
+            "Tuesday": 0,
+            "Wednesday": 0,
+            "Thursday": 0,
+            "Friday": 0,
+            "Saturday": 0,
+            "Sunday": 0,
+        }
+
+    def add(self, cell: TimetableCell, day: str, hour: int):
+        if self.timetable[hour][day] is not None:
+            return False
+        self.timetable[hour][day] = cell
+        self.daily_tally[day] += 1
+        return True

--- a/src/timetables.py
+++ b/src/timetables.py
@@ -89,7 +89,9 @@ def separate_sections_into_types(
 
 
 def generate_intra_combinations(
-    filtered_json: Annotated[dict, "filtered json file"]
+    filtered_json: Annotated[
+        dict, "filtered json file, i.e, with only courses selected"
+    ]
 ) -> dict:
     """
     Function that generates all possible combinations of sections within each course
@@ -125,3 +127,27 @@ def generate_intra_combinations(
         # generate all possible combinations of sections (exhaustive and inclusive of clashes)
         combs[cdc] = list(product(*sections))
     return combs
+
+
+def generate_exhaustive_timetables(
+    filtered_json: Annotated[
+        dict, "filtered json file, i.e, with only courses selected"
+    ]
+) -> list:
+    """
+    Function that generates all possible timetables (exhaustive and inclusive of clashes)
+
+    Returns:
+        list: list of all possible timetables (exhaustive and inclusive of clashes)
+    """
+
+    # written only for CDCs as of now
+
+    combs = generate_intra_combinations(filtered_json)
+    timetables = []
+    cdcs = []
+    for cdc in combs:
+        # format (course, section combination for that course)
+        cdcs.append([(str(cdc), comb) for comb in combs[cdc]])
+    timetables = list(product(*cdcs))
+    return timetables

--- a/src/timetables.py
+++ b/src/timetables.py
@@ -43,3 +43,85 @@ def get_filtered_json(
     for OPEL in OPELs:
         filtered_json["OPELs"][OPEL] = json[OPEL]
     return filtered_json
+
+
+def separate_sections_into_types(
+    filtered_json: Annotated[
+        dict, "filtered json file, i.e, with only courses selected"
+    ]
+) -> dict:
+    """
+    Function to separate the sections into lectures, tutorials and practicals
+
+    Returns:
+        dict: dictionary of courses' sections separated into lectures, tutorials and practicals
+    """
+
+    # currently written only for CDCs
+
+    sep = {}
+    for cdc in filtered_json["CDCs"]:
+        lectures = []
+        tutorials = []
+        practicals = []
+        # inner dictionary we'll be continuously referring to
+        ref = filtered_json["CDCs"][cdc]
+        for section in ref["sections"]:
+            if section.startswith("L"):
+                lectures.append(section)
+            elif section.startswith("T"):
+                tutorials.append(section)
+            elif section.startswith("P"):
+                practicals.append(section)
+        sep[cdc] = {
+            "L": lectures,
+            "T": tutorials,
+            "P": practicals,
+        }
+        # if list is empty remove the key-value pair
+        # we need to remove it as it causes problems when using woth itertools.product()
+        if not lectures:
+            del sep[cdc]["L"]
+        if not tutorials:
+            del sep[cdc]["T"]
+        if not practicals:
+            del sep[cdc]["P"]
+
+
+def generate_intra_combinations(
+    filtered_json: Annotated[dict, "filtered json file"]
+) -> dict:
+    """
+    Function that generates all possible combinations of sections within each course
+
+    Returns:
+        dict: dictionary of all possible combinations of sections within each course
+    """
+
+    # again, written only for CDCs as of now
+    sep = separate_sections_into_types(filtered_json)
+    combs = {}
+    for cdc in sep:
+        sections = []
+        # first check is the type of section (L, T or P) is present in the course
+        if sep[cdc].get("L") is not None:
+            # number of lecture sections
+            nLs = len(sep[cdc]["L"])
+            # list of lecture sections
+            Ls = ["L" + str(i + 1) for i in range(nLs)]
+            sections.append(Ls)
+        if sep[cdc].get("P") is not None:
+            # number of practical sections
+            nPs = len(sep[cdc]["P"])
+            Ps = ["P" + str(i + 1) for i in range(nPs)]
+            # list of practical sections
+            sections.append(Ps)
+        if sep[cdc].get("T") is not None:
+            # number of tutorial sections
+            nTs = len(sep[cdc]["T"])
+            # list of tutorial sections
+            Ts = ["T" + str(i + 1) for i in range(nTs)]
+            sections.append(Ts)
+        # generate all possible combinations of sections (exhaustive and inclusive of clashes)
+        combs[cdc] = list(product(*sections))
+    return combs

--- a/src/timetables.py
+++ b/src/timetables.py
@@ -3,23 +3,6 @@ from itertools import product
 from typing import Annotated
 
 
-# Global Variables
-
-CDCs = ["CS F342", "CS F363", "CS F364"]
-
-# Currently not working with electives
-
-DEls = []
-
-OPELs = []
-
-HUELs = []
-
-# Load the json file created
-
-tt_json = json.load(open("timetable.json", "r"))
-
-
 def get_filtered_json(
     json: Annotated[dict, "main timetable json file"],
     CDCs: Annotated[list[str], "list of BITS codes for CDCs selected"],
@@ -200,3 +183,31 @@ def remove_clashes(
             filtered.append(timetable)
 
     return filtered
+
+
+if __name__ == "__main__":
+    # Global Variables
+
+    CDCs = ["CS F342", "CS F363", "CS F364"]
+
+    # Currently not working with electives
+
+    DEls = []
+
+    OPELs = []
+
+    HUELs = []
+
+    # Load the json file created
+
+    tt_json = json.load(open("timetable.json", "r"))
+
+    filtered_json = get_filtered_json(tt_json, CDCs, DEls, HUELs, OPELs)
+
+    exhaustive_list_of_timetables = generate_exhaustive_timetables(filtered_json)
+
+    timetables_without_clashes = remove_clashes(
+        exhaustive_list_of_timetables, filtered_json
+    )
+
+    print("Number of timetables without clashes:", len(timetables_without_clashes))

--- a/src/timetables.py
+++ b/src/timetables.py
@@ -70,6 +70,8 @@ def separate_sections_into_types(
         if not practicals:
             del sep[cdc]["P"]
 
+    return sep
+
 
 def generate_intra_combinations(
     filtered_json: Annotated[

--- a/src/timetables.py
+++ b/src/timetables.py
@@ -1,0 +1,45 @@
+import json
+from itertools import product
+from typing import Annotated
+
+
+# Global Variables
+
+CDCs = ["CS F342", "CS F363", "CS F364"]
+
+# Currently not working with electives
+
+DEls = []
+
+OPELs = []
+
+HUELs = []
+
+# Load the json file created
+
+tt_json = json.load(open("timetable.json", "r"))
+
+
+def get_filtered_json(
+    json: Annotated[dict, "main timetable json file"],
+    CDCs: Annotated[list[str], "list of BITS codes for CDCs selected"],
+    DEls: Annotated[list[str], "list of BITS codes for DEls selected"],
+    HUELs: Annotated[list[str], "list of BITS codes for HUELs selected"],
+    OPELs: Annotated[list[str], "list of BITS codes for OPELs selected"],
+) -> dict:
+    """
+    Function to filter the main timetable json file to only include the selected courses
+
+    Returns:
+        dict: filtered json file
+    """
+    filtered_json = {"CDCs": {}, "DEls": {}, "HUELs": {}, "OPELs": {}}
+    for CDC in CDCs:
+        filtered_json["CDCs"][CDC] = json[CDC]
+    for DEL in DEls:
+        filtered_json["DEls"][DEL] = json[DEL]
+    for HUEL in HUELs:
+        filtered_json["HUELs"][HUEL] = json[HUEL]
+    for OPEL in OPELs:
+        filtered_json["OPELs"][OPEL] = json[OPEL]
+    return filtered_json


### PR DESCRIPTION
Added functionality to find all possible timetables for the given set of courses without any clash

Next steps:

1. Add exam clash checks
2. Add basic filters to make it easier for people to come up with multiple timetables at once suited to their need.
3. Convert it to a CLI tool
4. Add more filters as necessary
5. Start documenting as its now starting to get a little messy